### PR TITLE
Fix: Load React app bundle in index.html

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,5 +8,6 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <script src="/bundle.js"></script>
   </body>
 </html>


### PR DESCRIPTION
The existing public/index.html file did not include a script tag to load the compiled React application. This change adds a <script src="/bundle.js"></script> tag before the closing </body>.

This allows the React application, assumed to be bundled into `bundle.js` and available at the server root, to be loaded and rendered when public/index.html is accessed.

Verification:
1. Ensure a JavaScript bundle file named `bundle.js` (containing the compiled React app) is present in the root directory from which `public/index.html` is served.
   - If `public/index.html` is accessed via a server (e.g., `http://localhost/public/index.html`), `bundle.js` should be accessible at `http://localhost/bundle.js`.
   - If `public/index.html` is opened as a local file, `bundle.js` should typically reside in the directory directly containing the `public` folder.
2. Open `public/index.html` in a web browser.
3. The React application should render. Check the browser's developer console for any errors, particularly 404 errors for `/bundle.js`, which would indicate it's not found at the expected location.